### PR TITLE
Update version to 1.0.7 and enhance release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,11 @@ name: Gradle Plugin Portal Release
 
 on:
   release:
-    types: [ published ]  # triggers when you publish (not just create) a release
+    types: [ prereleased, released ]
 
 jobs:
-  gradleRelease:
+  release:
+    name: Publish Plugin
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -59,22 +60,23 @@ jobs:
           BRANCH="changelog-update-$VERSION"
           LABEL="release changelog"
           
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
           
-          git checkout -b "$BRANCH"
+          git checkout -b $BRANCH
           git commit -am "Changelog update - $VERSION"
-          git push --set-upstream origin "$BRANCH"
+          git push --set-upstream origin $BRANCH
           
           gh label create "$LABEL" \
             --description "Pull requests with release changelog update" \
-            --force || true
+            --force \
+            || true
           
           gh pr create \
             --title "Changelog update - \`$VERSION\`" \
-            --body "This PR updates the \`CHANGELOG.md\` file for the \`$VERSION\` version." \
+            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
             --label "$LABEL" \
-            --head "$BRANCH"
+            --head $BRANCH
 
         # Publish to Gradle Plugin Portal
       - name: Publish to Gradle Plugin Portal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Gradle Plugin Portal Release
+name: Release
 
 on:
   release:

--- a/ADPP/labels.list
+++ b/ADPP/labels.list
@@ -3,5 +3,5 @@
 <labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/labels.xsd">
   <primary-label id="azd" short-name="azure devops pipeline" name="Azure DevOps Pipeline Plugin" color="green">Azure DevOps Pipeline</primary-label>
-  <secondary-label id="azd_version" name="V1.0.5" color="blue">New in version 2024.3</secondary-label>
+  <secondary-label id="azd_version" name="V1.0.7" color="blue">New in version 1.0.7</secondary-label>
 </labels>

--- a/ADPP/topics/Overview.topic
+++ b/ADPP/topics/Overview.topic
@@ -21,6 +21,13 @@
          border-effect="line"/>
   </sub>
 
+  <chapter title="Requirements" id="requirements-overview-chapter">
+    <list type="bullet" id="requirements-bullets">
+      <li>Gradle Project with <b>Kotlin DSL</b> and version <b>8.9+</b></li>
+      <li>Azure DevOps account</li>
+    </list>
+  </chapter>
+
   <chapter title="Features" id="features-overview-chapter">
     <list type="bullet" id="features-bullets">
       <li>Generate Azure DevOps pipeline YAML files from Gradle DSL</li>
@@ -30,12 +37,5 @@
     </list>
   </chapter>
 
-
-  <chapter title="Requirements" id="requirements-overview-chapter">
-    <list type="bullet" id="requirements-bullets">
-      <li>Gradle <b>8.9+</b></li>
-      <li>Azure DevOps account</li>
-    </list>
-  </chapter>
 
 </topic>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Azure DevOps Pipeline Plugin
 
+[![GitHub stars](https://img.shields.io/github/stars/Jonatha1983/azure-devops-plugin?style=social)](https://github.com/Jonatha1983/azure-devops-plugin/stargazers)
 [![Build](https://github.com/Jonatha1983/azure-devops-plugin/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/Jonatha1983/azure-devops-plugin/actions/workflows/build.yaml)
 [![codecov](https://codecov.io/gh/Jonatha1983/azure-devops-plugin/graph/badge.svg?token=7011WZ10IR)](https://codecov.io/gh/Jonatha1983/azure-devops-plugin)
+[![GitHub release](https://img.shields.io/github/v/release/Jonatha1983/azure-devops-plugin?label=Latest%20Release&style=flat-square&color=blue)](https://github.com/Jonatha1983/azure-devops-plugin/releases/latest)
+
+⚠️ **Important Notice**:  
+This plugin is designed exclusively for use with **Gradle Kotlin DSL** (`build.gradle.kts`) and does not support **Groovy DSL** (`build.gradle`). Please ensure your project is
+configured accordingly.
 
 The Azure DevOps Pipeline Plugin is a [Gradle](https://docs.gradle.org/current/userguide/userguide.html) plugin that
 allows you to generate Azure DevOps pipeline YAML files from your Gradle project.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 azdpp.group=com.dorkag.azuredevops
 azdpp.name=pipelines
-azdpp.version=1.0.6
+azdpp.version=1.0.7
 repositoryUrl=https://github.com/Jonatha1983/azure-devops-plugin
 


### PR DESCRIPTION
### Description

- Update the plugin version to 1.0.7 in `gradle.properties`.
- Adjust labels to reflect the new version.
- Improve GitHub Actions release workflow:
    - Add support for prereleases.
    - Rename the release job for clarity.
    - Refine Git configuration for better changelog PR creation.

