### PR TITLE
Update to version 1.0.9 and optimize Gradle caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,19 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          # For main branch: write-only mode (don't read cache)
+          cache-write-only: ${{ github.ref == 'refs/heads/main' }}
+          # For PR branches: read-write mode with strict matching
+          cache-read-only: false
+          gradle-home-cache-strict-match: ${{ github.event_name == 'pull_request' }}
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          gradle-home-cache-excludes: |
+            user-switches.xml
+            wrapper/dists/**/*.lock
 
       # Extract version and changelog from Gradle
       - name: Export Properties
@@ -63,6 +76,19 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          # For main branch: write-only mode (don't read cache)
+          cache-write-only: ${{ github.ref == 'refs/heads/main' }}
+          # For PR branches: read-write mode with strict matching
+          cache-read-only: false
+          gradle-home-cache-strict-match: ${{ github.event_name == 'pull_request' }}
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          gradle-home-cache-excludes: |
+            user-switches.xml
+            wrapper/dists/**/*.lock
 
       # Run Check
       - name: Run Check

--- a/ADPP/labels.list
+++ b/ADPP/labels.list
@@ -3,5 +3,5 @@
 <labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/labels.xsd">
   <primary-label id="azd" short-name="azure devops pipeline" name="Azure DevOps Pipeline Plugin" color="green">Azure DevOps Pipeline</primary-label>
-  <secondary-label id="azd_version" name="V1.0.8" color="blue">New in version 1.0.8</secondary-label>
+  <secondary-label id="azd_version" name="V1.0.9" color="blue">New in version 1.0.9</secondary-label>
 </labels>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Azure DevOps Pipeline Plugin
 
 [![GitHub stars](https://img.shields.io/github/stars/Jonatha1983/azure-devops-plugin?style=social)](https://github.com/Jonatha1983/azure-devops-plugin/stargazers)
+
 [![Build](https://github.com/Jonatha1983/azure-devops-plugin/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/Jonatha1983/azure-devops-plugin/actions/workflows/build.yaml)
 [![codecov](https://codecov.io/gh/Jonatha1983/azure-devops-plugin/graph/badge.svg?token=7011WZ10IR)](https://codecov.io/gh/Jonatha1983/azure-devops-plugin)
+[![Release](https://github.com/Jonatha1983/azure-devops-plugin/actions/workflows/release.yml/badge.svg)](https://github.com/Jonatha1983/azure-devops-plugin/actions/workflows/release.yml)
 [![GitHub release](https://img.shields.io/github/v/release/Jonatha1983/azure-devops-plugin?label=Latest%20Release&style=flat-square&color=blue)](https://github.com/Jonatha1983/azure-devops-plugin/releases/latest)
 
 ⚠️ **Important Notice**:  

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 azdpp.group=com.dorkag.azuredevops
 azdpp.name=pipelines
-azdpp.version=1.0.8
+azdpp.version=1.0.9
 repositoryUrl=https://github.com/Jonatha1983/azure-devops-plugin
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ Azure DevOps Pipelines Plugin
 
 ### Added
 
+- More documentation and examples.
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
### Description
- Incremented the plugin version to 1.0.9 across required files.
- Improved GitHub Actions workflow by refining the Gradle caching strategy to differentiate behavior for main and PR branches.
- Added a release workflow badge to the README for better visibility. 

### Checklist
- [x] Documentation updated (if necessary)
- [x] Tests added or updated (if necessary)
- [x] All CI checks pass