### PR TITLE
Update Azure DevOps plugin to version 1.0.11

### DIFF
--- a/ADPP/topics/Getting-Started.topic
+++ b/ADPP/topics/Getting-Started.topic
@@ -13,7 +13,7 @@
     </p>
     <code-block lang="kotlin">
             plugins {
-              id("com.dorkag.azuredevops") version "1.0.1"
+              id("com.dorkag.azuredevops") version "1.0.11"
             }
 
             azurePipeline {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 azdpp.group=com.dorkag.azuredevops
 azdpp.name=pipelines
-azdpp.version=1.0.10
+azdpp.version=1.0.11
 repositoryUrl=https://github.com/Jonatha1983/azure-devops-plugin
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ Azure DevOps Pipelines Plugin
 
 ### Added
 
+- Gradle Portal release plugin.
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
### Description
- Upgraded Azure DevOps plugin to version `1.0.11` to ensure compatibility with the latest features.
- Updated `build script` and `gradle.properties` accordingly.
- Added a note in the changelog about the plugin's Gradle Portal release.
- No changes made to core functional logic.