### PR TITLE
Add Gradle Portal release plugin and update Azure DevOps plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 azdpp.group=com.dorkag.azuredevops
 azdpp.name=pipelines
-azdpp.version=1.0.11
+azdpp.version=1.0.12
 repositoryUrl=https://github.com/Jonatha1983/azure-devops-plugin
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ Azure DevOps Pipelines Plugin
 
 ### Added
 
+- Gradle Portal release plugin. 
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
### Summary

This pull request includes the following updates:
- **Gradle Portal release plugin:** Added an entry to the `CHANGELOG` to notify users of the new feature.
- **Azure DevOps plugin version update:** Bumped the version to `1.0.12` in `gradle.properties`. This ensures compatibility with new improvements without altering core functionality.

### Motivation

These changes aim to keep the project up-to-date with recent improvements and provide clear documentation regarding plugin updates.

